### PR TITLE
0.2.4: Fix default exports to use proper ecmascript style

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-nested-validation",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A toolkit for performing nested validation of React forms.",
   "esnext": "src/index.js",
   "main": "dist/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-export asForm from './asForm'
-export asFormWizard from './asFormWizard'
-export Form from './Form'
+export { default as asForm } from './asForm'
+export { default as asFormWizard } from './asFormWizard'
+export { default as Form }from './Form'
 export * from './validators'


### PR DESCRIPTION
This change will fix the export syntax so that the package can be imported by other packages that don't use the @babel/plugin-proposal-export-default-from plugin. 